### PR TITLE
Revert "klte-common: Disable sdcardfs"

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -69,7 +69,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Storage
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sys.sdcardfs=false
+    ro.sys.sdcardfs=true
 
 # Tethering
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
This reverts commit 4f33809cf6c6e02e5f01e5b99e59b7d7f992ef44.

* The cause for the apparent space leak (until unmount) is caused by
  asymmetric access by Android to the upper vs. lower filesystems on
  external storage and the fact that sdcardfs maintained upper/lower
  icache and dcache that are not synched. While normally only visible
  to users on external sdcards, it could be forced on internal storage
  by twiddling /data/media/0 and /sdcard.
* See https://review.lineageos.org/#/c/193137/ for resolution.

Change-Id: Ia642815aef2f7e7ab76507a27cdc7cd1d4648028